### PR TITLE
Fixed error: Chat Adapter Error Event: RTM Error: Received unmapped event "reconnect_url":

### DIFF
--- a/websocket_managed_conn.go
+++ b/websocket_managed_conn.go
@@ -416,4 +416,5 @@ var eventMapping = map[string]interface{}{
 
 	"reaction_added":   ReactionAddedEvent{},
 	"reaction_removed": ReactionRemovedEvent{},
+	"reconnect_url":    ReconnectUrlEvent{},
 }

--- a/websocket_misc.go
+++ b/websocket_misc.go
@@ -98,3 +98,9 @@ type BotChangedEvent struct {
 type AccountsChangedEvent struct {
 	Type string `json:"type"`
 }
+
+// ReconnectUrlEvent represents the receiving reconnect url event
+type ReconnectUrlEvent struct {
+	Type string `json:"type"`
+	URL  string `json:"url"`
+}


### PR DESCRIPTION
When using this, the error `Chat Adapter Error Event: RTM Error: Received unmapped event "reconnect_url":`. [nlopes/slack](github.com/nlopes/slack) fixed this error 12 days ago in commit [a148f03](https://github.com/nlopes/slack/commit/a148f037aa4f9a8722c25e4a692b0a0e27e756a0). This is pull request is just to use that commit to fix the reconnect url event.
