### PR TITLE
Fix connection failure by not forcing inclusion of port number in ws url

### DIFF
--- a/rtm.go
+++ b/rtm.go
@@ -24,12 +24,7 @@ func (api *Client) StartRTM() (info *Info, websocketURL string, err error) {
 	// Fixed by: https://github.com/golang/net/commit/5058c78c3627b31e484a81463acd51c7cecc06f3
 	// but slack returns the address with no port, so we have to fix it
 	api.Debugln("Using URL:", response.Info.URL)
-	websocketURL, err = websocketizeUrlPort(response.Info.URL)
-	if err != nil {
-		return nil, "", fmt.Errorf("parsing response URL: %s", err)
-	}
-
-	return &response.Info, websocketURL, nil
+	return &response.Info, response.Info.URL, nil
 }
 
 // NewRTM returns a RTM, which provides a fully managed connection to

--- a/websocket_utils.go
+++ b/websocket_utils.go
@@ -3,8 +3,6 @@ package slack
 import (
 	"fmt"
 	"log"
-	"net"
-	"net/url"
 	"strconv"
 	"time"
 )
@@ -24,18 +22,4 @@ func (t JSONTimeString) String() string {
 	timeStr := int64(floatN)
 	tm := time.Unix(int64(timeStr), 0)
 	return fmt.Sprintf("\"%s\"", tm.Format("Mon Jan _2"))
-}
-
-var portMapping = map[string]string{"ws": "80", "wss": "443"}
-
-func websocketizeUrlPort(orig string) (string, error) {
-	urlObj, err := url.ParseRequestURI(orig)
-	if err != nil {
-		return "", err
-	}
-	_, _, err = net.SplitHostPort(urlObj.Host)
-	if err != nil {
-		return urlObj.Scheme + "://" + urlObj.Host + ":" + portMapping[urlObj.Scheme] + urlObj.Path, nil
-	}
-	return orig, nil
 }


### PR DESCRIPTION
Slack recently changed its RTM endpoint behavior and regressed this library, as well as the original nlopes library. The problem is that the code forces the injection of a port number into the URL given by Slack, and that causes the library to not be able to initiate a connection properly.

This change backports the fix from https://github.com/nlopes/slack/pull/217 into this repository. I've verified it fixes the issue (my bot written with FogCreek/victor can now connect).